### PR TITLE
fix condition for using constant

### DIFF
--- a/Http.php
+++ b/Http.php
@@ -481,7 +481,7 @@ class Http extends Generic implements \Hoa\Core\Parameter\Parameterizable {
 
             $defaultPort = $self->getDefaultPort($secure);
 
-            if(false === $secure)
+            if(static::UNSECURE === $secure)
                 return 80 !== $defaultPort ? ':' . $defaultPort : '';
 
             return 443 !== $defaultPort ? ':' . $defaultPort  : '';


### PR DESCRIPTION
In order to use constant for secure/unsecure port
Then this condition should also use it
