### PR TITLE
use http_host when its defined

### DIFF
--- a/Http/Http.php
+++ b/Http/Http.php
@@ -713,10 +713,6 @@ class Http extends Router\Generic implements Core\Parameter\Parameterizable {
 
             if(isset($_SERVER['HTTP_HOST']))
                 $domain = $_SERVER['HTTP_HOST'];
-
-            else if(isset($_SERVER['SERVER_NAME']))
-                $domain = $_SERVER['SERVER_NAME'];
-
             else
                 $domain = $_SERVER['SERVER_ADDR'];
 

--- a/Http/Http.php
+++ b/Http/Http.php
@@ -711,9 +711,9 @@ class Http extends Router\Generic implements Core\Parameter\Parameterizable {
             if('cli' === php_sapi_name())
                 return $domain = '';
 
-            if(isset($_SERVER['HTTP_HOST']))
-                $domain = $_SERVER['HTTP_HOST'];
-            else
+            $domain = $_SERVER['HTTP_HOST'];
+
+            if(empty($domain))
                 $domain = $_SERVER['SERVER_ADDR'];
 
             if(0 !== preg_match('#^(.+):' . static::getPort() . '$#', $domain, $m))

--- a/Http/Http.php
+++ b/Http/Http.php
@@ -711,7 +711,11 @@ class Http extends Router\Generic implements Core\Parameter\Parameterizable {
             if('cli' === php_sapi_name())
                 return $domain = '';
 
-            $domain = $_SERVER['SERVER_NAME'];
+            if(isset($_SERVER['HTTP_HOST']))
+                $domain = $_SERVER['HTTP_HOST'];
+
+            if(empty($domain))
+                $domain = $_SERVER['SERVER_NAME'];
 
             if(empty($domain))
                 $domain = $_SERVER['SERVER_ADDR'];

--- a/Http/Http.php
+++ b/Http/Http.php
@@ -714,10 +714,10 @@ class Http extends Router\Generic implements Core\Parameter\Parameterizable {
             if(isset($_SERVER['HTTP_HOST']))
                 $domain = $_SERVER['HTTP_HOST'];
 
-            if(empty($domain))
+            else if(isset($_SERVER['SERVER_NAME']))
                 $domain = $_SERVER['SERVER_NAME'];
 
-            if(empty($domain))
+            else
                 $domain = $_SERVER['SERVER_ADDR'];
 
             if(0 !== preg_match('#^(.+):' . static::getPort() . '$#', $domain, $m))


### PR DESCRIPTION
When i use subdomain on hoa like : `'(?<user>.*)@/'` i use it on an nginx configuration on default configuration and SERVER_NAME has not mention of subdomain you have the export below : 
```
Array
(
    [USER] => www-data
    [HOME] => /var/www
    [FCGI_ROLE] => RESPONDER
    [QUERY_STRING] => q=
    [REQUEST_METHOD] => GET
    [CONTENT_TYPE] => 
    [CONTENT_LENGTH] => 
    [SCRIPT_FILENAME] => /maestria-web/Public/index.php
    [SCRIPT_NAME] => /index.php
    [REQUEST_URI] => /
    [DOCUMENT_URI] => /index.php
    [DOCUMENT_ROOT] => /maestria-web/Public
    [SERVER_PROTOCOL] => HTTP/1.1
    [GATEWAY_INTERFACE] => CGI/1.1
    [SERVER_SOFTWARE] => nginx/1.4.6
    [REMOTE_ADDR] => 10.0.2.2
    [REMOTE_PORT] => 59023
    [SERVER_ADDR] => 10.0.2.15
    [SERVER_PORT] => 80
    [SERVER_NAME] => maestria.dev
    [REDIRECT_STATUS] => 200
    [HTTP_HOST] => foo.maestria.dev:8080
    [HTTP_USER_AGENT] => Mozilla/5.0 (Windows NT 6.3; WOW64; rv:36.0) Gecko/20100101 Firefox/36.0
    [HTTP_ACCEPT] => text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
    [HTTP_ACCEPT_LANGUAGE] => fr-FR,fr;q=0.8,en-US;q=0.5,en;q=0.3
    [HTTP_ACCEPT_ENCODING] => gzip, deflate
    [HTTP_DNT] => 1
    [HTTP_CONNECTION] => keep-alive
    [PHP_SELF] => /index.php
    [REQUEST_TIME_FLOAT] => 1426860307.3234
    [REQUEST_TIME] => 1426860307
)
```
The current code getDomain did't have subdomain mention and don't able to route the subdomain information, and my patch work correctly on my vm.
I think i don't introduce an BC-BREAK but i did't have an apache for test it.