### PR TITLE
Filter protected variables when unrouting

### DIFF
--- a/Http/Http.php
+++ b/Http/Http.php
@@ -621,7 +621,13 @@ class Http extends Router\Generic implements Core\Parameter\Parameterizable
         Array $variables,
         $allowEmpty = true
     ) {
-        $unusedVariables = $variables;
+        $unusedVariables = [];
+
+        foreach ($variables as $key => $variable) {
+            if ('_' !== $key[0]) {
+                $unusedVariables[$key] = $variable;
+            }
+        }
 
         // (?<named>…)
         $out = preg_replace_callback(


### PR DESCRIPTION
Fix #33. /cc @K-Phoen and @osaris 

Previous commit transformed unused variables as query strings when unrouting. However, the `unroute` method also receives protected variables (such as `_domain`, `_query` and also `_this` for the kit in case of a dispatcher etc.).

This commit filters unused variables to remove protected variables.