### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Options   : --some options
 
 The use of the [`Hoa\Console`
 library](http://central.hoa-project.net/Resource/Library/Console) would be a
-good idea to interprete the options and getting some confortable services for
+good idea to interprete the options and getting some comfortable services for
 the terminal.
 
 ## Documentation


### PR DESCRIPTION
@hoaproject, I've corrected a typographical error in the documentation of the [Router](https://github.com/hoaproject/Router) project. Specifically, I've changed confortable to comfortable. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.